### PR TITLE
feat: allow aggregate to output to specific file

### DIFF
--- a/examples/aggregate/app/BUILD.bazel
+++ b/examples/aggregate/app/BUILD.bazel
@@ -14,13 +14,16 @@ formatjs_aggregate(
     ],
 )
 
-# Snapshot test - verifies that aggregated messages match the expected fixture
-# Run `bazel run //app:update_all_messages_fixture` to update the snapshot
-write_source_files(
-    name = "update_all_messages_fixture",
-    files = {
-        "all_messages.fixture.json": ":all_messages",
-    },
+# Aggregate messages from module2 and module3
+# Module3 depends on module1, so module1's messages should be included transitively
+# This demonstrates that the aspect properly traverses the dependency graph
+formatjs_aggregate(
+    name = "transitive_messages",
+    out = "transitive_messages.json",
+    deps = [
+        "//module2:messages",
+        "//module3:messages",
+    ],
 )
 
 # Test target - verifies the snapshot hasn't changed
@@ -28,5 +31,6 @@ write_source_files(
     name = "aggregation_test",
     files = {
         "all_messages.fixture.json": ":all_messages",
+        "transitive_messages.fixture.json": ":transitive_messages.json",
     },
 )

--- a/examples/aggregate/app/transitive_messages.fixture.json
+++ b/examples/aggregate/app/transitive_messages.fixture.json
@@ -1,0 +1,42 @@
+{
+  "common.cancel": {
+    "id": "common.cancel",
+    "defaultMessage": "Cancel",
+    "description": "Common cancel button"
+  },
+  "common.save": {
+    "id": "common.save",
+    "defaultMessage": "Save",
+    "description": "Common save button"
+  },
+  "module1.description": {
+    "id": "module1.description",
+    "defaultMessage": "This is the first module",
+    "description": "Description for module 1"
+  },
+  "module1.title": {
+    "id": "module1.title",
+    "defaultMessage": "Module 1 Title",
+    "description": "Title for module 1"
+  },
+  "module2.description": {
+    "id": "module2.description",
+    "defaultMessage": "This is the second module",
+    "description": "Description for module 2"
+  },
+  "module2.title": {
+    "id": "module2.title",
+    "defaultMessage": "Module 2 Title",
+    "description": "Title for module 2"
+  },
+  "module3.description": {
+    "id": "module3.description",
+    "defaultMessage": "This is the third module",
+    "description": "Description for module 3"
+  },
+  "module3.title": {
+    "id": "module3.title",
+    "defaultMessage": "Module 3 Title",
+    "description": "Title for module 3"
+  }
+}


### PR DESCRIPTION
# Add transitive dependency support to formatjs_aggregate

### TL;DR

Added support for transitive message aggregation and improved documentation for cross-platform compatibility.

### What changed?

- Added a new `out` attribute to `formatjs_aggregate` rule to specify custom output file names
- Created a new `transitive_messages` example that demonstrates proper traversal of the dependency graph
- Added comprehensive documentation about platform support (macOS, Linux, Windows)
- Improved documentation with details about cross-platform builds, output groups, and usage patterns
- Added a fixture file to verify transitive dependency resolution works correctly

### How to test?

1. Build the new transitive messages example:
   ```bash
   bazel build //examples/aggregate/app:transitive_messages
   ```

2. Verify that messages from module1 are included even though it's only a transitive dependency:
   ```bash
   bazel test //examples/aggregate/app:aggregation_test
   ```

3. Test on different platforms to verify consistent output across macOS, Linux, and Windows

### Why make this change?

This change ensures that the formatjs_aggregate rule properly handles transitive dependencies, which is crucial for large monorepos where message dependencies might be nested several levels deep. The improved documentation makes it clear that the rules work across all major platforms without special configuration, which helps users understand the cross-platform capabilities of the toolchain.