### PR TITLE
fix: remove ignore_directories from REPO.bazel for Bazel 7 compat

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,7 @@
+# Examples are separate workspaces
+examples
+# Bazel convenience symlinks
+bazel-bin
+bazel-out
+bazel-rules_formatjs
+bazel-testlogs

--- a/REPO.bazel
+++ b/REPO.bazel
@@ -5,13 +5,3 @@ repo(
         "//:package_metadata",
     ],
 )
-
-ignore_directories([
-    # Examples are separate workspaces
-    "examples",
-    # Bazel convenience symlinks
-    "bazel-bin",
-    "bazel-out",
-    "bazel-rules_formatjs",
-    "bazel-testlogs",
-])


### PR DESCRIPTION
## Summary
- Remove `ignore_directories` from `REPO.bazel` since it was introduced in Bazel 8 and causes parse errors for Bazel 7 users consuming this module
- Add `.bazelignore` with the same entries as a backward-compatible alternative for local development

Fixes #40

## Test plan
- [ ] Verify CI passes
- [ ] Verify Bazel 7 users can consume this module without `REPO.bazel` parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)