### PR TITLE
feat: add formatjs_cli v1.1.0 and v1.1.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -44,7 +44,7 @@ bazel_dep(name = "rules_shell", version = "0.3.0", dev_dependency = True)
 
 # FormatJS CLI toolchain
 formatjs_cli = use_extension("//formatjs_cli:extensions.bzl", "formatjs_cli")
-formatjs_cli.toolchain(version = "1.0.0")
+formatjs_cli.toolchain(version = "1.1.1")
 use_repo(
     formatjs_cli,
     "formatjs_cli_toolchains",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -221,14 +221,14 @@
   "moduleExtensions": {
     "//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "Isj3L84GNr8g0Dr0yItPBw/NwcaOak8Gz1fVHv8FYwI=",
-        "usagesDigest": "yP/7Kjh7948f1JrIW0GMFFVzuAnQLfYJqdVTqkVlpc8=",
+        "bzlTransitiveDigest": "Dx44iGITOa48exi2WFKg3rzM18FLCuAXrH2muSnONYY=",
+        "usagesDigest": "6a99XjhcZCe5E6qdWgU04K8XTvjVZt+51xy4CuzkENE=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "formatjs_cli_toolchains_darwin_arm64": {
             "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.0.0",
+              "version": "1.1.1",
               "platform": "darwin-arm64",
               "exec_compatible_with": [
                 "@platforms//os:macos",
@@ -246,7 +246,7 @@
           "formatjs_cli_toolchains_linux_x64": {
             "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.0.0",
+              "version": "1.1.1",
               "platform": "linux-x64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -286,6 +286,28 @@
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO",
           "reproducible": false
+        }
+      }
+    },
+    "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
+      "general": {
+        "bzlTransitiveDigest": "06cynZ1bCvvy8zHPrrDlXq+Z68xmjctHpfFxi+zEpJY=",
+        "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
+        "recordedInputs": [
+          "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
+          "FILE:@@pybind11_bazel+//MODULE.bazel e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
+        ],
+        "generatedRepoSpecs": {
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
+              "strip_prefix": "pybind11-2.12.0",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
+              ]
+            }
+          }
         }
       }
     },

--- a/formatjs_cli/repositories.bzl
+++ b/formatjs_cli/repositories.bzl
@@ -1,8 +1,28 @@
 """Repository rules for FormatJS CLI toolchains."""
 
-DEFAULT_VERSION = "1.0.0"
+DEFAULT_VERSION = "1.1.1"
 
 FORMATJS_CLI_VERSIONS = {
+    "1.1.1": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.1/formatjs_cli-darwin-arm64",
+            "sha256": "72ce1ff57b907c3dc02c5bee23fcc5ca719f8a2b44f53f71198f6f0d495d1544",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.1/formatjs_cli-linux-x64",
+            "sha256": "1fea414a956ebdda974919c9fb9b3f49b37f6a0ea7dd59be940f4fde5440a2e5",
+        },
+    },
+    "1.1.0": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.0/formatjs_cli-darwin-arm64",
+            "sha256": "efb7e59e9cb33a09d258cb32b0884ee29792cb4c9a751970edb9ab563a15ad15",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.0/formatjs_cli-linux-x64",
+            "sha256": "fc7475d9d5bb34a160dfbf6f0d146376df0e562ef26ce9904ef9c98a3540fc3f",
+        },
+    },
     "1.0.0": {
         "darwin-arm64": {
             "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.0.0/formatjs_cli-darwin-arm64",


### PR DESCRIPTION
## Summary
- Add formatjs_cli versions 1.1.0 and 1.1.1 with darwin-arm64 and linux-x64 binaries
- Bump default version to 1.1.1

## Test plan
- [x] `bazel test //...` passes locally (11/11 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)