### PR TITLE
build: sync formatjs_cli versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -44,7 +44,7 @@ bazel_dep(name = "rules_shell", version = "0.3.0", dev_dependency = True)
 
 # FormatJS CLI toolchain
 formatjs_cli = use_extension("//formatjs_cli:extensions.bzl", "formatjs_cli")
-formatjs_cli.toolchain(version = "1.1.1")
+formatjs_cli.toolchain(version = "1.1.4")
 use_repo(
     formatjs_cli,
     "formatjs_cli_toolchains",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -221,14 +221,14 @@
   "moduleExtensions": {
     "//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "Dx44iGITOa48exi2WFKg3rzM18FLCuAXrH2muSnONYY=",
-        "usagesDigest": "6a99XjhcZCe5E6qdWgU04K8XTvjVZt+51xy4CuzkENE=",
+        "bzlTransitiveDigest": "+AVHe/HMDHCtw6ozyCyrGxLfR4q3sCYMGxCeq/OF/i4=",
+        "usagesDigest": "zV8uaDmVFlIiOqgvKfmnHb66rF4cJ1bVBmAars9ekEg=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "formatjs_cli_toolchains_darwin_arm64": {
             "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.1",
+              "version": "1.1.4",
               "platform": "darwin-arm64",
               "exec_compatible_with": [
                 "@platforms//os:macos",
@@ -246,7 +246,7 @@
           "formatjs_cli_toolchains_linux_x64": {
             "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.1",
+              "version": "1.1.4",
               "platform": "linux-x64",
               "exec_compatible_with": [
                 "@platforms//os:linux",

--- a/examples/custom_version/MODULE.bazel
+++ b/examples/custom_version/MODULE.bazel
@@ -1,6 +1,6 @@
 """Example demonstrating custom FormatJS CLI version configuration.
 
-This example shows how to use a custom version (0.1.0) that is not in the built-in
+This example shows how to use custom FormatJS CLI binary URLs instead of the built-in
 FORMATJS_CLI_VERSIONS dictionary. This is useful for:
 - Testing unreleased versions
 - Using custom builds
@@ -18,8 +18,7 @@ local_path_override(
     path = "../..",
 )
 
-# Configure custom FormatJS CLI version 0.1.0
-# This version was removed from the built-in versions but we can still use it
+# Configure custom FormatJS CLI binary URLs for version 0.1.0
 formatjs_cli = use_extension("@rules_formatjs//formatjs_cli:extensions.bzl", "formatjs_cli")
 
 # Single toolchain call with custom binaries (similar to rules_nodejs pattern)
@@ -53,7 +52,7 @@ use_repo(
 )
 
 # Register the custom version toolchains (0.1.0)
-# Note: Standard toolchains (0.1.2) are already registered by rules_formatjs root MODULE.bazel
+# Note: Standard toolchains are already registered by rules_formatjs root MODULE.bazel
 # Bazel will select the appropriate one based on platform constraints and registration order
 register_toolchains(
     "@formatjs_v0_1_0_toolchains//:all",

--- a/examples/custom_version/README.md
+++ b/examples/custom_version/README.md
@@ -1,10 +1,10 @@
-# Custom FormatJS CLI Version Example
+# Custom FormatJS CLI Binary Example
 
-This example demonstrates how to use a custom FormatJS CLI version that is not included in the built-in `FORMATJS_CLI_VERSIONS` dictionary.
+This example demonstrates how to use custom FormatJS CLI binary URLs instead of the built-in `FORMATJS_CLI_VERSIONS` dictionary.
 
 ## What This Example Shows
 
-- **Custom Version Configuration**: How to use version 0.1.0, which was removed from the built-in versions
+- **Custom Binary Configuration**: How to provide explicit URLs and checksums for version 0.1.0
 - **Simple Ergonomic API**: Just provide version, platform, url, and sha256 - no manual platform constraints needed
 - **Message Extraction**: A working example of extracting messages using the custom CLI version
 
@@ -82,7 +82,7 @@ In this example:
 
 - On macOS ARM64: The custom 0.1.0 darwin-arm64 toolchain is available
 - On Linux x64: The custom 0.1.0 linux-x64 toolchain is available
-- The standard 0.1.2 toolchains (from rules_formatjs root MODULE.bazel) are also available
+- The standard toolchains from the rules_formatjs root MODULE.bazel are also available
 - Bazel will select the best match based on platform constraints
 
 ## Running the Example
@@ -162,7 +162,7 @@ When you build the `:messages` target, it will create a `messages.json` file con
 
 ## Comparison with Standard Toolchains
 
-This example does NOT call `formatjs_cli.toolchain()` because we're only using custom binaries. However, the root MODULE.bazel of `rules_formatjs` does call it, so standard toolchains (0.1.2) are also available.
+This example does NOT call `formatjs_cli.toolchain()` without custom repositories because we're only using custom binaries. However, the root MODULE.bazel of `rules_formatjs` does call it, so standard toolchains are also available.
 
 If you want to completely override and use only custom versions, you can still do so - Bazel will prefer the custom toolchains if they match the platform constraints.
 

--- a/formatjs_cli/extensions.bzl
+++ b/formatjs_cli/extensions.bzl
@@ -255,7 +255,7 @@ formatjs_cli = module_extension(
     ## Advanced: Custom Platform Binaries
 
     If you need to use a custom binary for a specific platform (e.g., unreleased version,
-    custom build, or older version not in the built-in list), configure custom platforms
+    custom build, or platform not in the built-in list), configure custom platforms
     in a single toolchain call:
 
     ```starlark
@@ -295,7 +295,8 @@ formatjs_cli = module_extension(
 
     ## Version History
 
-    - **0.1.2**: Latest version with native key sorting
+    - **1.1.4**: Latest built-in version
+    - **0.1.2**: Added native key sorting
     - **0.1.1**: Added key sorting support
     - **0.1.0**: Initial release
 

--- a/formatjs_cli/repositories.bzl
+++ b/formatjs_cli/repositories.bzl
@@ -1,8 +1,38 @@
 """Repository rules for FormatJS CLI toolchains."""
 
-DEFAULT_VERSION = "1.1.1"
+DEFAULT_VERSION = "1.1.4"
 
 FORMATJS_CLI_VERSIONS = {
+    "1.1.4": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.4/formatjs_cli-darwin-arm64",
+            "sha256": "dd3bd223f0c1dddfa136d4ce4299fa3e43ce36e7d3b4b9a8c7ac6131f888f810",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.4/formatjs_cli-linux-x64",
+            "sha256": "2d8a02030d7a83279dbd2cc02837e5d8cd3081bcadace4314e5d14d973ea36b9",
+        },
+    },
+    "1.1.3": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.3/formatjs_cli-darwin-arm64",
+            "sha256": "dd3bd223f0c1dddfa136d4ce4299fa3e43ce36e7d3b4b9a8c7ac6131f888f810",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.3/formatjs_cli-linux-x64",
+            "sha256": "1664d61b08d466c7a278e51ddce1cd6905a0ac1d81e70f941fceaaeaba60b136",
+        },
+    },
+    "1.1.2": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.2/formatjs_cli-darwin-arm64",
+            "sha256": "faccf69c391b16cf5c08ce05bd2c5cdf8868f30f365940a7496e13abd4b3ed6e",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.2/formatjs_cli-linux-x64",
+            "sha256": "f5dc23f43e261114dafe403f01609cf789d426e480c72b8bf0be8b20160a3b5d",
+        },
+    },
     "1.1.1": {
         "darwin-arm64": {
             "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.1/formatjs_cli-darwin-arm64",
@@ -33,6 +63,36 @@ FORMATJS_CLI_VERSIONS = {
             "sha256": "d692809446523d613b2e2f6a49d225f8f8296afd3412c5cc2d136660ab51faa1",
         },
     },
+    "0.1.14": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.14/formatjs_cli-darwin-arm64",
+            "sha256": "e4c032973f299f6f7c6f73c5556d75219b99fd337f286c5931cd21a1c0d499a8",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.14/formatjs_cli-linux-x64",
+            "sha256": "f880c7986b6994c8f5e9d5fa59842c036e6badd838d5862ac8e2ea7226d1c53c",
+        },
+    },
+    "0.1.13": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.13/formatjs_cli-darwin-arm64",
+            "sha256": "4a19a68fcaa4280e93c6abb00ad4c32e34442f6e62bd947c73c037a85bb69fc3",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.13/formatjs_cli-linux-x64",
+            "sha256": "25f948156faf66ba3e0febafa191d258d17689b9de5d13c23b2d0f305d84b829",
+        },
+    },
+    "0.1.12": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.12/formatjs_cli-darwin-arm64",
+            "sha256": "14810ea377a3f0bc0f527fdd3675b3aff7d23b9fcb541f9d79488a27baad36d8",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.12/formatjs_cli-linux-x64",
+            "sha256": "a6779e36c17ed36401d4598dca2e1affcb23c45676887414241ae65d02f32067",
+        },
+    },
     "0.1.11": {
         "darwin-arm64": {
             "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.11/formatjs_cli-darwin-arm64",
@@ -41,6 +101,16 @@ FORMATJS_CLI_VERSIONS = {
         "linux-x64": {
             "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.11/formatjs_cli-linux-x64",
             "sha256": "9361021a9f23a810737d41f809de7379f350c98411b4337ad562a17a3f3533bb",
+        },
+    },
+    "0.1.10": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.10/formatjs_cli-darwin-arm64",
+            "sha256": "107de7ab0b51de1de4c1b52d25c1dd6330d9689a544e832cf7e371b169bdf7eb",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.10/formatjs_cli-linux-x64",
+            "sha256": "bbfbf1f718e3094353a5dec2767a1aa6200bf2031e7561643de14684a1a8e360",
         },
     },
     "0.1.9": {
@@ -61,6 +131,16 @@ FORMATJS_CLI_VERSIONS = {
         "linux-x64": {
             "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.8/formatjs_cli-linux-x64",
             "sha256": "6d57d42a83d90f9bf311c23e3754a214a855e965a538de1fe68b54553320a587",
+        },
+    },
+    "0.1.7": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.7/formatjs_cli-darwin-arm64",
+            "sha256": "2500c526bd4f355d8803be85a435bc0fb68d71c9e2528444c95c02ec22f81da1",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.7/formatjs_cli-linux-x64",
+            "sha256": "017728adc9a0f376f738a101af0627f7e9bf8e6eb76455599aa4b7836009ffa3",
         },
     },
     "0.1.6": {
@@ -121,6 +201,16 @@ FORMATJS_CLI_VERSIONS = {
         "linux-x64": {
             "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.1/formatjs_cli-linux-x64",
             "sha256": "7bfbce944b780c0b12ec4d8362ae5e0e9ab8b745573f8a367228b14f64c7175b",
+        },
+    },
+    "0.1.0": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.0/formatjs_cli-darwin-arm64",
+            "sha256": "9b2c736b48cc65e763cf19ac7c190e527f9a8d4aa0798185e602f58becb99feb",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v0.1.0/formatjs_cli-linux-x64",
+            "sha256": "884b9a41b9f6be649ea72277ebf22af0146043466d2ab94b28a57f95ffb7da1a",
         },
     },
 }


### PR DESCRIPTION
## Summary
- add all currently published formatjs_cli binary releases to FORMATJS_CLI_VERSIONS
- bump the default CLI toolchain from 1.1.1 to 1.1.4
- refresh custom binary example docs now that 0.1.0 is built in

## Test
- bazel test //...