### PR TITLE
feat: update formatjs cli to 1.1.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,3 +41,32 @@ jobs:
             ${{ matrix.folder }}/bazel-testlogs/**/test.xml
           if-no-files-found: warn
           retention-days: 7
+
+  linux-arm64-smoke:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-linux-arm64
+          repository-cache: true
+
+      - name: Verify Linux ARM64 CLI alias
+        run: |
+          bazel cquery 'somepath(//formatjs_cli:cli, @formatjs_cli_toolchains_linux_aarch64//:cli)'
+
+      - name: Smoke test Linux ARM64 CLI
+        run: |
+          bazel test //tests/arguments:test_fixtures_0_test
+
+      - name: Upload test logs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-logs-ubuntu-24.04-arm
+          path: |
+            bazel-testlogs/**/test.log
+            bazel-testlogs/**/test.xml
+          if-no-files-found: warn
+          retention-days: 7

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -44,7 +44,7 @@ bazel_dep(name = "rules_shell", version = "0.3.0", dev_dependency = True)
 
 # FormatJS CLI toolchain
 formatjs_cli = use_extension("//formatjs_cli:extensions.bzl", "formatjs_cli")
-formatjs_cli.toolchain(version = "1.1.4")
+formatjs_cli.toolchain(version = "1.1.5")
 use_repo(
     formatjs_cli,
     "formatjs_cli_toolchains",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -221,14 +221,14 @@
   "moduleExtensions": {
     "//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "+AVHe/HMDHCtw6ozyCyrGxLfR4q3sCYMGxCeq/OF/i4=",
-        "usagesDigest": "zV8uaDmVFlIiOqgvKfmnHb66rF4cJ1bVBmAars9ekEg=",
+        "bzlTransitiveDigest": "j3u/j7mKho/ZNtAM3lFtjkZpBMasCS9583pb3iPhNJc=",
+        "usagesDigest": "w8+si1QvrI13j2rvr2Q74OpmyaVayidS9DCSAR4n3xE=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "formatjs_cli_toolchains_darwin_arm64": {
             "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.4",
+              "version": "1.1.5",
               "platform": "darwin-arm64",
               "exec_compatible_with": [
                 "@platforms//os:macos",
@@ -246,7 +246,7 @@
           "formatjs_cli_toolchains_linux_x64": {
             "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.4",
+              "version": "1.1.5",
               "platform": "linux-x64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -256,9 +256,15 @@
             }
           },
           "formatjs_cli_toolchains_linux_aarch64": {
-            "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_placeholder_repo",
+            "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "platform": "linux-aarch64"
+              "version": "1.1.5",
+              "platform": "linux-aarch64",
+              "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:aarch64"
+              ],
+              "target_compatible_with": []
             }
           },
           "formatjs_cli_toolchains_windows_x86_64": {

--- a/examples/aggregate/MODULE.bazel.lock
+++ b/examples/aggregate/MODULE.bazel.lock
@@ -149,8 +149,8 @@
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/MODULE.bazel": "1f98ed015f7e744a745e0df6e898a7c5e83562d6b759dfd475c76456dda5ccea",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/source.json": "b038c0c07e12e658135bbc32cc1a2ded6e33785105c9d41958014c592de4593e",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -223,7 +223,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "06cynZ1bCvvy8zHPrrDlXq+Z68xmjctHpfFxi+zEpJY=",
+        "bzlTransitiveDigest": "b+RP7Sgl8KN0VHamrgTqzGLuYPcQ/Mo4ptNkkHUIIlA=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedInputs": [
           "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
@@ -245,14 +245,14 @@
     },
     "@@rules_formatjs+//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "Isj3L84GNr8g0Dr0yItPBw/NwcaOak8Gz1fVHv8FYwI=",
-        "usagesDigest": "vQyEgW0XwBuTU1g9G+wnL4mjDCFeWwapMEXrP+HPG3U=",
+        "bzlTransitiveDigest": "ew51Vw92Nw7vITQ2o5mkAnEib5uVgeWjKVn2DiCNy2Q=",
+        "usagesDigest": "RkNnWs19/IGTp7wWwev/iqoiM71il5XNpLJvHtp+4CU=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "formatjs_cli_toolchains_darwin_arm64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.0.0",
+              "version": "1.1.5",
               "platform": "darwin-arm64",
               "exec_compatible_with": [
                 "@platforms//os:macos",
@@ -270,7 +270,7 @@
           "formatjs_cli_toolchains_linux_x64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.0.0",
+              "version": "1.1.5",
               "platform": "linux-x64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -280,9 +280,15 @@
             }
           },
           "formatjs_cli_toolchains_linux_aarch64": {
-            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_placeholder_repo",
+            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "platform": "linux-aarch64"
+              "version": "1.1.5",
+              "platform": "linux-aarch64",
+              "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:aarch64"
+              ],
+              "target_compatible_with": []
             }
           },
           "formatjs_cli_toolchains_windows_x86_64": {
@@ -315,7 +321,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "ABI1D/sbS1ovwaW/kHDoj8nnXjQ0oKU9fzmzEG4iT8o=",
+        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -372,7 +378,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
+        "bzlTransitiveDigest": "iibnRYgg8LpcfmH7EAnVwYePC3jsVaJ6Id8XxUjSZps=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",

--- a/examples/custom_version/MODULE.bazel.lock
+++ b/examples/custom_version/MODULE.bazel.lock
@@ -136,8 +136,8 @@
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/MODULE.bazel": "1f98ed015f7e744a745e0df6e898a7c5e83562d6b759dfd475c76456dda5ccea",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/source.json": "b038c0c07e12e658135bbc32cc1a2ded6e33785105c9d41958014c592de4593e",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -175,7 +175,8 @@
     "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
     "https://bcr.bazel.build/modules/rules_shell/0.4.1/MODULE.bazel": "00e501db01bbf4e3e1dd1595959092c2fadf2087b2852d3f553b5370f5633592",
     "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
-    "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
+    "https://bcr.bazel.build/modules/rules_shell/0.8.0/MODULE.bazel": "f6a89f1d6a669a26f28fe814503857055d76306b79cfc11d12399af08d0b80ae",
+    "https://bcr.bazel.build/modules/rules_shell/0.8.0/source.json": "eb53cc815bc503c6683c5fe12d943f98883f81fc22f51403ec8a95610cba4195",
     "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
     "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
     "https://bcr.bazel.build/modules/rules_swift/2.4.0/MODULE.bazel": "1639617eb1ede28d774d967a738b4a68b0accb40650beadb57c21846beab5efd",
@@ -199,7 +200,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "06cynZ1bCvvy8zHPrrDlXq+Z68xmjctHpfFxi+zEpJY=",
+        "bzlTransitiveDigest": "b+RP7Sgl8KN0VHamrgTqzGLuYPcQ/Mo4ptNkkHUIIlA=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedInputs": [
           "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
@@ -221,8 +222,8 @@
     },
     "@@rules_formatjs+//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "Isj3L84GNr8g0Dr0yItPBw/NwcaOak8Gz1fVHv8FYwI=",
-        "usagesDigest": "GjBykxtaQAGkYVK1K01YboUcv/ilV2ht++IfV1YwYYQ=",
+        "bzlTransitiveDigest": "ew51Vw92Nw7vITQ2o5mkAnEib5uVgeWjKVn2DiCNy2Q=",
+        "usagesDigest": "BXG06s0q5WfsFKIg7AsF6nT544CdMNtBrk5KLk/hcQY=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "formatjs_v0_1_0_darwin_arm64": {
@@ -262,7 +263,7 @@
           "formatjs_cli_toolchains_darwin_arm64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.0.0",
+              "version": "1.1.5",
               "platform": "darwin-arm64",
               "exec_compatible_with": [
                 "@platforms//os:macos",
@@ -280,7 +281,7 @@
           "formatjs_cli_toolchains_linux_x64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.0.0",
+              "version": "1.1.5",
               "platform": "linux-x64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -290,9 +291,15 @@
             }
           },
           "formatjs_cli_toolchains_linux_aarch64": {
-            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_placeholder_repo",
+            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "platform": "linux-aarch64"
+              "version": "1.1.5",
+              "platform": "linux-aarch64",
+              "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:aarch64"
+              ],
+              "target_compatible_with": []
             }
           },
           "formatjs_cli_toolchains_windows_x86_64": {
@@ -328,7 +335,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "ABI1D/sbS1ovwaW/kHDoj8nnXjQ0oKU9fzmzEG4iT8o=",
+        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -385,7 +392,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
+        "bzlTransitiveDigest": "iibnRYgg8LpcfmH7EAnVwYePC3jsVaJ6Id8XxUjSZps=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",

--- a/examples/simple/MODULE.bazel.lock
+++ b/examples/simple/MODULE.bazel.lock
@@ -149,8 +149,8 @@
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
     "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/MODULE.bazel": "1f98ed015f7e744a745e0df6e898a7c5e83562d6b759dfd475c76456dda5ccea",
-    "https://bcr.bazel.build/modules/rules_java/9.0.3/source.json": "b038c0c07e12e658135bbc32cc1a2ded6e33785105c9d41958014c592de4593e",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/MODULE.bazel": "ee63f27e36a3fada80342869361182f120a9819c74320e8e65b1e04ba0cd7a9d",
+    "https://bcr.bazel.build/modules/rules_java/9.1.0/source.json": "da589573c1dee2c9ac4a568b301269a2e8191110ff0345c1a959fa7ea6c4dfd6",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -223,7 +223,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "06cynZ1bCvvy8zHPrrDlXq+Z68xmjctHpfFxi+zEpJY=",
+        "bzlTransitiveDigest": "b+RP7Sgl8KN0VHamrgTqzGLuYPcQ/Mo4ptNkkHUIIlA=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedInputs": [
           "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
@@ -245,14 +245,14 @@
     },
     "@@rules_formatjs+//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "Isj3L84GNr8g0Dr0yItPBw/NwcaOak8Gz1fVHv8FYwI=",
-        "usagesDigest": "vQyEgW0XwBuTU1g9G+wnL4mjDCFeWwapMEXrP+HPG3U=",
+        "bzlTransitiveDigest": "ew51Vw92Nw7vITQ2o5mkAnEib5uVgeWjKVn2DiCNy2Q=",
+        "usagesDigest": "RkNnWs19/IGTp7wWwev/iqoiM71il5XNpLJvHtp+4CU=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "formatjs_cli_toolchains_darwin_arm64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.0.0",
+              "version": "1.1.5",
               "platform": "darwin-arm64",
               "exec_compatible_with": [
                 "@platforms//os:macos",
@@ -270,7 +270,7 @@
           "formatjs_cli_toolchains_linux_x64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.0.0",
+              "version": "1.1.5",
               "platform": "linux-x64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -280,9 +280,15 @@
             }
           },
           "formatjs_cli_toolchains_linux_aarch64": {
-            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_placeholder_repo",
+            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "platform": "linux-aarch64"
+              "version": "1.1.5",
+              "platform": "linux-aarch64",
+              "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:aarch64"
+              ],
+              "target_compatible_with": []
             }
           },
           "formatjs_cli_toolchains_windows_x86_64": {
@@ -315,7 +321,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "ABI1D/sbS1ovwaW/kHDoj8nnXjQ0oKU9fzmzEG4iT8o=",
+        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -372,7 +378,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
+        "bzlTransitiveDigest": "iibnRYgg8LpcfmH7EAnVwYePC3jsVaJ6Id8XxUjSZps=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",

--- a/formatjs_cli/BUILD.bazel
+++ b/formatjs_cli/BUILD.bazel
@@ -4,13 +4,41 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
+config_setting(
+    name = "darwin_arm64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "linux_aarch64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+config_setting(
+    name = "linux_x64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 # Alias that resolves to the correct toolchain CLI based on platform
 # This is used by verify.bzl which can't use toolchains directly
 alias(
     name = "cli",
-    actual = select({
-        "@platforms//os:osx": "@formatjs_cli_toolchains_darwin_arm64//:cli",
-        "@platforms//os:linux": "@formatjs_cli_toolchains_linux_x64//:cli",
-    }),
+    actual = select(
+        {
+            ":darwin_arm64": "@formatjs_cli_toolchains_darwin_arm64//:cli",
+            ":linux_aarch64": "@formatjs_cli_toolchains_linux_aarch64//:cli",
+            ":linux_x64": "@formatjs_cli_toolchains_linux_x64//:cli",
+        },
+        no_match_error = "No FormatJS CLI binary is available for this target platform.",
+    ),
     visibility = ["//visibility:public"],
 )

--- a/formatjs_cli/extensions.bzl
+++ b/formatjs_cli/extensions.bzl
@@ -295,7 +295,7 @@ formatjs_cli = module_extension(
 
     ## Version History
 
-    - **1.1.4**: Latest built-in version
+    - **1.1.5**: Latest built-in version with Linux ARM64 support
     - **0.1.2**: Added native key sorting
     - **0.1.1**: Added key sorting support
     - **0.1.0**: Initial release

--- a/formatjs_cli/repositories.bzl
+++ b/formatjs_cli/repositories.bzl
@@ -1,8 +1,22 @@
 """Repository rules for FormatJS CLI toolchains."""
 
-DEFAULT_VERSION = "1.1.4"
+DEFAULT_VERSION = "1.1.5"
 
 FORMATJS_CLI_VERSIONS = {
+    "1.1.5": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.5/formatjs_cli-darwin-arm64",
+            "sha256": "381e20f9e73e8e2bd5a0494fb438ee3341e018355701c7ab35a298b787663809",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.5/formatjs_cli-linux-x64",
+            "sha256": "874900a9e8a0462a880dba3786e16927901a9162f64ef4fe0862d54d32247542",
+        },
+        "linux-aarch64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.5/formatjs_cli-linux-arm64",
+            "sha256": "de2d27ae03ad83dadb7c40ec9884160415714362d7a54a1b6265d6b9c0ed4544",
+        },
+    },
     "1.1.4": {
         "darwin-arm64": {
             "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.4/formatjs_cli-darwin-arm64",
@@ -291,7 +305,7 @@ _formatjs_cli_repo = repository_rule(
         ),
         "platform": attr.string(
             mandatory = True,
-            doc = "Target platform (e.g., 'darwin-arm64', 'linux-x64')",
+            doc = "Target platform (e.g., 'darwin-arm64', 'linux-x64', 'linux-aarch64')",
         ),
         "url": attr.string(
             doc = """Custom URL to download the FormatJS CLI binary from.
@@ -461,7 +475,7 @@ def formatjs_cli_register_toolchains(name, version = DEFAULT_VERSION, register =
             target_compatible_with = [],
         )
 
-    # Linux aarch64 - placeholder for now
+    # Linux aarch64
     repo_name = "{}_linux_aarch64".format(name)
     if "linux-aarch64" in FORMATJS_CLI_VERSIONS[version]:
         _formatjs_cli_repo(


### PR DESCRIPTION
Summary:
- Update built-in formatjs_cli to 1.1.5.
- Add Linux ARM64 binary support and platform-aware CLI alias selection.
- Add a ubuntu-24.04-arm GitHub Actions smoke job for the ARM64 CLI.

Tests:
- bazel test //...
- bazel build @formatjs_cli_toolchains_linux_aarch64//:cli //formatjs_cli:cli
- bazel cquery 'somepath(//formatjs_cli:cli, @formatjs_cli_toolchains_linux_aarch64//:cli)' with a temporary Linux ARM64 platform during local verification