### PR TITLE
feat: add formatjs_cli versions through 1.1.12

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -45,7 +45,7 @@ bazel_dep(name = "rules_shell", version = "0.3.0", dev_dependency = True)
 
 # FormatJS CLI toolchain
 formatjs_cli = use_extension("//formatjs_cli:extensions.bzl", "formatjs_cli")
-formatjs_cli.toolchain(version = "1.1.5")
+formatjs_cli.toolchain(version = "1.1.12")
 use_repo(
     formatjs_cli,
     "formatjs_cli_toolchains",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -226,14 +226,14 @@
   "moduleExtensions": {
     "//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "j3u/j7mKho/ZNtAM3lFtjkZpBMasCS9583pb3iPhNJc=",
-        "usagesDigest": "w8+si1QvrI13j2rvr2Q74OpmyaVayidS9DCSAR4n3xE=",
+        "bzlTransitiveDigest": "KEXKr0c3dIbbWXx4Dd3dA07r817WCmPwn9skzugZTEg=",
+        "usagesDigest": "L6WX9aF5BkUwpqL1FFHITrWq+scHf1JzYcuiaPxP7es=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "formatjs_cli_toolchains_darwin_arm64": {
             "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "darwin-arm64",
               "exec_compatible_with": [
                 "@platforms//os:macos",
@@ -251,7 +251,7 @@
           "formatjs_cli_toolchains_linux_x64": {
             "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "linux-x64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -263,7 +263,7 @@
           "formatjs_cli_toolchains_linux_aarch64": {
             "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "linux-aarch64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -273,9 +273,15 @@
             }
           },
           "formatjs_cli_toolchains_windows_x86_64": {
-            "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_placeholder_repo",
+            "repoRuleId": "@@//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "platform": "windows-x86_64"
+              "version": "1.1.12",
+              "platform": "windows-x86_64",
+              "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64"
+              ],
+              "target_compatible_with": []
             }
           },
           "formatjs_cli_toolchains": {

--- a/README.md
+++ b/README.md
@@ -321,8 +321,9 @@ my_aspect = aspect(
 
 rules_formatjs uses a native Rust CLI toolchain that is automatically downloaded for your platform. The toolchain supports:
 
-- macOS (Apple Silicon and Intel)
-- Linux (x86_64)
+- macOS (Apple Silicon)
+- Linux (x86_64 and ARM64)
+- Windows (x86_64)
 
 The toolchain is registered automatically when you add the MODULE.bazel dependency. Binaries are fetched from GitHub releases and cached by Bazel.
 

--- a/examples/aggregate/MODULE.bazel.lock
+++ b/examples/aggregate/MODULE.bazel.lock
@@ -245,14 +245,14 @@
     },
     "@@rules_formatjs+//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "j3u/j7mKho/ZNtAM3lFtjkZpBMasCS9583pb3iPhNJc=",
-        "usagesDigest": "RkNnWs19/IGTp7wWwev/iqoiM71il5XNpLJvHtp+4CU=",
+        "bzlTransitiveDigest": "KEXKr0c3dIbbWXx4Dd3dA07r817WCmPwn9skzugZTEg=",
+        "usagesDigest": "+lJ/MAcUgSG8lRl6wdw3Y74KrfnafWrDNTsYttQYmWA=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "formatjs_cli_toolchains_darwin_arm64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "darwin-arm64",
               "exec_compatible_with": [
                 "@platforms//os:macos",
@@ -270,7 +270,7 @@
           "formatjs_cli_toolchains_linux_x64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "linux-x64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -282,7 +282,7 @@
           "formatjs_cli_toolchains_linux_aarch64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "linux-aarch64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -292,9 +292,15 @@
             }
           },
           "formatjs_cli_toolchains_windows_x86_64": {
-            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_placeholder_repo",
+            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "platform": "windows-x86_64"
+              "version": "1.1.12",
+              "platform": "windows-x86_64",
+              "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64"
+              ],
+              "target_compatible_with": []
             }
           },
           "formatjs_cli_toolchains": {

--- a/examples/custom_version/MODULE.bazel.lock
+++ b/examples/custom_version/MODULE.bazel.lock
@@ -222,8 +222,8 @@
     },
     "@@rules_formatjs+//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "ew51Vw92Nw7vITQ2o5mkAnEib5uVgeWjKVn2DiCNy2Q=",
-        "usagesDigest": "BXG06s0q5WfsFKIg7AsF6nT544CdMNtBrk5KLk/hcQY=",
+        "bzlTransitiveDigest": "KEXKr0c3dIbbWXx4Dd3dA07r817WCmPwn9skzugZTEg=",
+        "usagesDigest": "Ll53ENNP/scQ8N9Qnn4iJRO4kjO6NFprA0j1S6YGPzI=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "formatjs_v0_1_0_darwin_arm64": {
@@ -263,7 +263,7 @@
           "formatjs_cli_toolchains_darwin_arm64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "darwin-arm64",
               "exec_compatible_with": [
                 "@platforms//os:macos",
@@ -281,7 +281,7 @@
           "formatjs_cli_toolchains_linux_x64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "linux-x64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -293,7 +293,7 @@
           "formatjs_cli_toolchains_linux_aarch64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "linux-aarch64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -303,9 +303,15 @@
             }
           },
           "formatjs_cli_toolchains_windows_x86_64": {
-            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_placeholder_repo",
+            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "platform": "windows-x86_64"
+              "version": "1.1.12",
+              "platform": "windows-x86_64",
+              "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64"
+              ],
+              "target_compatible_with": []
             }
           },
           "formatjs_cli_toolchains": {

--- a/examples/simple/MODULE.bazel.lock
+++ b/examples/simple/MODULE.bazel.lock
@@ -245,14 +245,14 @@
     },
     "@@rules_formatjs+//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "j3u/j7mKho/ZNtAM3lFtjkZpBMasCS9583pb3iPhNJc=",
-        "usagesDigest": "RkNnWs19/IGTp7wWwev/iqoiM71il5XNpLJvHtp+4CU=",
+        "bzlTransitiveDigest": "KEXKr0c3dIbbWXx4Dd3dA07r817WCmPwn9skzugZTEg=",
+        "usagesDigest": "+lJ/MAcUgSG8lRl6wdw3Y74KrfnafWrDNTsYttQYmWA=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "formatjs_cli_toolchains_darwin_arm64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "darwin-arm64",
               "exec_compatible_with": [
                 "@platforms//os:macos",
@@ -270,7 +270,7 @@
           "formatjs_cli_toolchains_linux_x64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "linux-x64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -282,7 +282,7 @@
           "formatjs_cli_toolchains_linux_aarch64": {
             "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "version": "1.1.5",
+              "version": "1.1.12",
               "platform": "linux-aarch64",
               "exec_compatible_with": [
                 "@platforms//os:linux",
@@ -292,9 +292,15 @@
             }
           },
           "formatjs_cli_toolchains_windows_x86_64": {
-            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_placeholder_repo",
+            "repoRuleId": "@@rules_formatjs+//formatjs_cli:repositories.bzl%_formatjs_cli_repo",
             "attributes": {
-              "platform": "windows-x86_64"
+              "version": "1.1.12",
+              "platform": "windows-x86_64",
+              "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64"
+              ],
+              "target_compatible_with": []
             }
           },
           "formatjs_cli_toolchains": {

--- a/formatjs_cli/BUILD.bazel
+++ b/formatjs_cli/BUILD.bazel
@@ -28,6 +28,14 @@ config_setting(
     ],
 )
 
+config_setting(
+    name = "windows_x86_64",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
 # Alias that resolves to the correct toolchain CLI based on platform
 # This is used by verify.bzl which can't use toolchains directly
 alias(
@@ -37,6 +45,7 @@ alias(
             ":darwin_arm64": "@formatjs_cli_toolchains_darwin_arm64//:cli",
             ":linux_aarch64": "@formatjs_cli_toolchains_linux_aarch64//:cli",
             ":linux_x64": "@formatjs_cli_toolchains_linux_x64//:cli",
+            ":windows_x86_64": "@formatjs_cli_toolchains_windows_x86_64//:cli",
         },
         no_match_error = "No FormatJS CLI binary is available for this target platform.",
     ),

--- a/formatjs_cli/extensions.bzl
+++ b/formatjs_cli/extensions.bzl
@@ -14,11 +14,11 @@ The current default version is defined by `DEFAULT_VERSION`.
 Current binaries are available for:
 - macOS Apple Silicon (darwin-arm64)
 - Linux x86_64 (linux-x64)
+- Linux ARM64 (linux-aarch64)
+- Windows x86_64 (windows-x86_64)
 
 Toolchain definitions also exist for future support:
 - macOS Intel (darwin-x86_64)
-- Linux aarch64 (linux-aarch64)
-- Windows x86_64 (windows-x86_64)
 
 ## Usage
 
@@ -295,7 +295,9 @@ formatjs_cli = module_extension(
 
     ## Version History
 
-    - **1.1.5**: Latest built-in version with Linux ARM64 support
+    - **1.1.12**: Latest built-in version
+    - **1.1.7**: Added Windows x86_64 support
+    - **1.1.5**: Added Linux ARM64 support
     - **0.1.2**: Added native key sorting
     - **0.1.1**: Added key sorting support
     - **0.1.0**: Initial release
@@ -307,11 +309,11 @@ formatjs_cli = module_extension(
     **Binaries currently available for:**
     - **macOS Apple Silicon** (M1/M2/M3): darwin-arm64 binary
     - **Linux x86_64**: linux-x64 binary
+    - **Linux ARM64**: linux-aarch64 binary
+    - **Windows x86_64**: windows-x86_64 binary
 
     **Toolchain definitions exist for future support:**
     - **macOS Intel**: darwin-x86_64
-    - **Linux aarch64**: linux-aarch64
-    - **Windows x86_64**: windows-x86_64
 
     If your platform doesn't have a binary available yet, the build will fail with a clear
     error message. Contributions for additional platform binaries are welcome!

--- a/formatjs_cli/repositories.bzl
+++ b/formatjs_cli/repositories.bzl
@@ -1,8 +1,116 @@
 """Repository rules for FormatJS CLI toolchains."""
 
-DEFAULT_VERSION = "1.1.5"
+DEFAULT_VERSION = "1.1.12"
 
 FORMATJS_CLI_VERSIONS = {
+    "1.1.12": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.12/formatjs_cli-darwin-arm64",
+            "sha256": "ad38f0cdade50bbc779458a154504dbdc37e85118125ecd65fe44a89056eff39",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.12/formatjs_cli-linux-x64",
+            "sha256": "284b985b69db188f6f1a752b2d93f3db72ff744a30ab10dac72bb97bcc51b7cb",
+        },
+        "linux-aarch64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.12/formatjs_cli-linux-arm64",
+            "sha256": "4ef27b1022d0bee6056cb2ce276be999e014b28ceb6569fe0c1ed154e42f1ccc",
+        },
+        "windows-x86_64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.12/formatjs_cli-win32-x64.exe",
+            "sha256": "e44e9321b4f676267dec462b2527fcbe1065bbcacae174e36bdb1eb895dcb295",
+        },
+    },
+    "1.1.11": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.11/formatjs_cli-darwin-arm64",
+            "sha256": "e280c4e879026826d98c647142110f8ade8f3c47f669b6e911196cdee2a07e89",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.11/formatjs_cli-linux-x64",
+            "sha256": "08d4c1bac673800280a898608256140eb814c85c9c01d8963c1d94feaec3efd6",
+        },
+        "linux-aarch64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.11/formatjs_cli-linux-arm64",
+            "sha256": "0ecff22da63eef4ef78a6f5cb16a8d47a6f316e450d4407d8ee0eec1d57fa18f",
+        },
+        "windows-x86_64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.11/formatjs_cli-win32-x64.exe",
+            "sha256": "badc12960ce1cd063b878d53c6870ae195d6e59a5f31ed554b8cc97815e62d73",
+        },
+    },
+    "1.1.10": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.10/formatjs_cli-darwin-arm64",
+            "sha256": "0a7df4f935245debf80caea8399708cb9401a07e05b6db37fdf39208b7dbeb8d",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.10/formatjs_cli-linux-x64",
+            "sha256": "9eab4839bb60a903a97d52f7b3c1c6678bcc62f0eef667657fbae6889d5bedc9",
+        },
+        "linux-aarch64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.10/formatjs_cli-linux-arm64",
+            "sha256": "c10af5084f60af5c8473a10cd5cd5ed1ee338ee3f7a4556051808154c7358f10",
+        },
+        "windows-x86_64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.10/formatjs_cli-win32-x64.exe",
+            "sha256": "f5a01600f10e3dba6571393c24a2af7aa9a6330ccdc213b9969e39c06a5caf14",
+        },
+    },
+    "1.1.9": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.9/formatjs_cli-darwin-arm64",
+            "sha256": "65e949967d7c706592cd7221b43bb9d370aec70dbac6699f8d039fb84954030c",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.9/formatjs_cli-linux-x64",
+            "sha256": "4ff049e8304cce383b5d4d3079f082ed3aa4dbb2fcf54da2731c4c7355584c18",
+        },
+        "linux-aarch64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.9/formatjs_cli-linux-arm64",
+            "sha256": "c53589acfe3c7841217cfefb81bf386f301e9f0c1b194bbc59732110055291cd",
+        },
+        "windows-x86_64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.9/formatjs_cli-win32-x64.exe",
+            "sha256": "122a22e7b7f32656180002262b651a5e6173d9ff521160c9339abc258bdc3e27",
+        },
+    },
+    "1.1.8": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.8/formatjs_cli-darwin-arm64",
+            "sha256": "dea78e2b0db1ded55d0cf479d420daadb6cf4004a24298bb536c04f512e6a2d6",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.8/formatjs_cli-linux-x64",
+            "sha256": "185e5d634cda3a5dec73dd210b953c89c9db747d2647145faf653d35a61e8587",
+        },
+        "linux-aarch64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.8/formatjs_cli-linux-arm64",
+            "sha256": "368226ce328f04a55c710ee6423e5b7ff80b3b1944184a432530f08ae437202e",
+        },
+        "windows-x86_64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.8/formatjs_cli-win32-x64.exe",
+            "sha256": "fd2b245c966c3febeb88cfe5a98e6f3d2046e9ebca58b81c446adf03ca8c09d2",
+        },
+    },
+    "1.1.7": {
+        "darwin-arm64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.7/formatjs_cli-darwin-arm64",
+            "sha256": "7bb0bb6123ac75bd20e5909f0da71ccb2443ef09482b00f035f49d28943b93a2",
+        },
+        "linux-x64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.7/formatjs_cli-linux-x64",
+            "sha256": "da18a495543cd83f11fe9f7b2f6c5466b456325cdc48a1b1434fb5313432cd67",
+        },
+        "linux-aarch64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.7/formatjs_cli-linux-arm64",
+            "sha256": "5a3e1f74ccbbee36078a83c2d03a24d111d5b0a5ea3e30a28868838e0f89e253",
+        },
+        "windows-x86_64": {
+            "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.7/formatjs_cli-win32-x64.exe",
+            "sha256": "6580944829a608ee426dde842bf25c17cf982188901ef6c021f3fc1ab32792f7",
+        },
+    },
     "1.1.5": {
         "darwin-arm64": {
             "url": "https://github.com/formatjs/formatjs/releases/download/formatjs_cli_v1.1.5/formatjs_cli-darwin-arm64",
@@ -494,7 +602,7 @@ def formatjs_cli_register_toolchains(name, version = DEFAULT_VERSION, register =
             platform = "linux-aarch64",
         )
 
-    # Windows x86_64 - placeholder for now
+    # Windows x86_64
     repo_name = "{}_windows_x86_64".format(name)
     if "windows-x86_64" in FORMATJS_CLI_VERSIONS[version]:
         _formatjs_cli_repo(


### PR DESCRIPTION
## Summary
- add built-in formatjs_cli release metadata for 1.1.7 through 1.1.12
- update the default toolchain to 1.1.12 and refresh module lockfiles
- document current Linux ARM64 and Windows x86_64 binary support

## Verification
- CI=true pnpm install --frozen-lockfile
- pnpm exec lefthook run pre-commit
- bazel test //...
- cd examples/simple && bazel test //...
- cd examples/aggregate && bazel test //...
- cd examples/custom_version && bazel test //...

Note: formatjs_cli_v1.1.6 has a tag but no GitHub release/assets. The published 1.1.12 Darwin asset checksum matches the release asset, but the binary still reports formatjs 1.1.9 via --version; this PR consumes the published release tags and checksums as-is.