### PR TITLE
feat: expose FormatJS CLI as executable target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,11 @@ jobs:
         working-directory: ${{ matrix.folder }}
         run: bazel test //...
 
+      - name: Run FormatJS CLI from a consumer workspace
+        if: matrix.folder == 'examples/simple'
+        working-directory: ${{ matrix.folder }}
+        run: bazel run @rules_formatjs//cli -- --version
+
       - name: Upload test logs
         if: failure()
         uses: actions/upload-artifact@v7
@@ -52,9 +57,9 @@ jobs:
           disk-cache: ${{ github.workflow }}-linux-arm64
           repository-cache: true
 
-      - name: Verify Linux ARM64 CLI alias
+      - name: Run Linux ARM64 CLI
         run: |
-          bazel cquery 'somepath(//formatjs_cli:cli, @formatjs_cli_toolchains_linux_aarch64//:cli)'
+          bazel run @rules_formatjs//cli -- --version
 
       - name: Smoke test Linux ARM64 CLI
         run: |
@@ -70,3 +75,18 @@ jobs:
             bazel-testlogs/**/test.xml
           if-no-files-found: warn
           retention-days: 7
+
+  windows-cli-smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-windows
+          repository-cache: true
+
+      - name: Run Windows CLI
+        working-directory: examples/simple
+        shell: bash
+        run: bazel run "@rules_formatjs//cli" -- --version

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -226,7 +226,7 @@
   "moduleExtensions": {
     "//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "KEXKr0c3dIbbWXx4Dd3dA07r817WCmPwn9skzugZTEg=",
+        "bzlTransitiveDigest": "jyvcSmowzBDDTuxIutdZ9N/e6Q2AjrNOS6PKWdLJd1M=",
         "usagesDigest": "L6WX9aF5BkUwpqL1FFHITrWq+scHf1JzYcuiaPxP7es=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ git_override(
 
 ## Usage
 
+### Run the FormatJS CLI
+
+The platform-specific CLI selected by the registered toolchain is directly runnable:
+
+```bash
+bazel run @rules_formatjs//cli -- --version
+```
+
+The same label can be used in executable or tool attributes. Apply the execution transition when declaring a Starlark attribute:
+
+```starlark
+"_formatjs_cli": attr.label(
+    default = Label("@rules_formatjs//cli"),
+    executable = True,
+    cfg = "exec",
+)
+```
+
 ### Extract Messages
 
 Extract internationalized messages from your source code:

--- a/cli/BUILD.bazel
+++ b/cli/BUILD.bazel
@@ -1,0 +1,5 @@
+alias(
+    name = "cli",
+    actual = "//formatjs_cli:cli",
+    visibility = ["//visibility:public"],
+)

--- a/examples/aggregate/MODULE.bazel.lock
+++ b/examples/aggregate/MODULE.bazel.lock
@@ -245,7 +245,7 @@
     },
     "@@rules_formatjs+//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "KEXKr0c3dIbbWXx4Dd3dA07r817WCmPwn9skzugZTEg=",
+        "bzlTransitiveDigest": "jyvcSmowzBDDTuxIutdZ9N/e6Q2AjrNOS6PKWdLJd1M=",
         "usagesDigest": "+lJ/MAcUgSG8lRl6wdw3Y74KrfnafWrDNTsYttQYmWA=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/examples/custom_version/MODULE.bazel.lock
+++ b/examples/custom_version/MODULE.bazel.lock
@@ -222,7 +222,7 @@
     },
     "@@rules_formatjs+//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "KEXKr0c3dIbbWXx4Dd3dA07r817WCmPwn9skzugZTEg=",
+        "bzlTransitiveDigest": "jyvcSmowzBDDTuxIutdZ9N/e6Q2AjrNOS6PKWdLJd1M=",
         "usagesDigest": "Ll53ENNP/scQ8N9Qnn4iJRO4kjO6NFprA0j1S6YGPzI=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/examples/simple/MODULE.bazel.lock
+++ b/examples/simple/MODULE.bazel.lock
@@ -245,7 +245,7 @@
     },
     "@@rules_formatjs+//formatjs_cli:extensions.bzl%formatjs_cli": {
       "general": {
-        "bzlTransitiveDigest": "KEXKr0c3dIbbWXx4Dd3dA07r817WCmPwn9skzugZTEg=",
+        "bzlTransitiveDigest": "jyvcSmowzBDDTuxIutdZ9N/e6Q2AjrNOS6PKWdLJd1M=",
         "usagesDigest": "+lJ/MAcUgSG8lRl6wdw3Y74KrfnafWrDNTsYttQYmWA=",
         "recordedInputs": [],
         "generatedRepoSpecs": {

--- a/formatjs_cli/BUILD.bazel
+++ b/formatjs_cli/BUILD.bazel
@@ -1,53 +1,13 @@
+load(":toolchain.bzl", "formatjs_cli_executable")
+
 # Toolchain type for FormatJS CLI
 toolchain_type(
     name = "toolchain_type",
     visibility = ["//visibility:public"],
 )
 
-config_setting(
-    name = "darwin_arm64",
-    constraint_values = [
-        "@platforms//os:osx",
-        "@platforms//cpu:arm64",
-    ],
-)
-
-config_setting(
-    name = "linux_aarch64",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:aarch64",
-    ],
-)
-
-config_setting(
-    name = "linux_x64",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
-)
-
-config_setting(
-    name = "windows_x86_64",
-    constraint_values = [
-        "@platforms//os:windows",
-        "@platforms//cpu:x86_64",
-    ],
-)
-
-# Alias that resolves to the correct toolchain CLI based on platform
-# This is used by verify.bzl which can't use toolchains directly
-alias(
+# Executable that resolves the CLI through the registered toolchain.
+formatjs_cli_executable(
     name = "cli",
-    actual = select(
-        {
-            ":darwin_arm64": "@formatjs_cli_toolchains_darwin_arm64//:cli",
-            ":linux_aarch64": "@formatjs_cli_toolchains_linux_aarch64//:cli",
-            ":linux_x64": "@formatjs_cli_toolchains_linux_x64//:cli",
-            ":windows_x86_64": "@formatjs_cli_toolchains_windows_x86_64//:cli",
-        },
-        no_match_error = "No FormatJS CLI binary is available for this target platform.",
-    ),
     visibility = ["//visibility:public"],
 )

--- a/formatjs_cli/repositories.bzl
+++ b/formatjs_cli/repositories.bzl
@@ -341,6 +341,7 @@ def _formatjs_cli_repo_impl(rctx):
     """Implementation for formatjs_cli repository rule."""
     platform = rctx.attr.platform
     version = rctx.attr.version
+    executable_name = "formatjs_cli.exe" if platform == "windows-x86_64" else "formatjs_cli"
 
     # Allow custom URL and SHA256 to be provided
     custom_url = rctx.attr.url
@@ -371,7 +372,7 @@ def _formatjs_cli_repo_impl(rctx):
 
     rctx.download(
         url = url,
-        output = "formatjs_cli",
+        output = executable_name,
         sha256 = sha256,
         executable = True,
     )
@@ -381,7 +382,7 @@ load("@rules_formatjs//formatjs_cli:toolchain.bzl", "formatjs_cli_toolchain")
 
 filegroup(
     name = "cli",
-    srcs = ["formatjs_cli"],
+    srcs = ["{executable_name}"],
     visibility = ["//visibility:public"],
 )
 
@@ -400,6 +401,7 @@ toolchain(
     visibility = ["//visibility:public"],
 )
 """.format(
+        executable_name = executable_name,
         exec_compatible_with = rctx.attr.exec_compatible_with,
         target_compatible_with = rctx.attr.target_compatible_with,
     ))

--- a/formatjs_cli/toolchain.bzl
+++ b/formatjs_cli/toolchain.bzl
@@ -30,3 +30,27 @@ formatjs_cli_toolchain = rule(
     },
     doc = "Defines a FormatJS CLI toolchain",
 )
+
+def _formatjs_cli_executable_impl(ctx):
+    """Expose the selected FormatJS CLI as an executable target."""
+    formatjs_cli = ctx.toolchains["@rules_formatjs//formatjs_cli:toolchain_type"].formatjs_cli_info.cli
+    extension = ".exe" if formatjs_cli.basename.endswith(".exe") else ""
+    executable = ctx.actions.declare_file(ctx.label.name + extension)
+
+    ctx.actions.symlink(
+        output = executable,
+        target_file = formatjs_cli,
+        is_executable = True,
+    )
+
+    return [DefaultInfo(
+        executable = executable,
+        runfiles = ctx.runfiles(files = [formatjs_cli]),
+    )]
+
+formatjs_cli_executable = rule(
+    implementation = _formatjs_cli_executable_impl,
+    executable = True,
+    toolchains = ["@rules_formatjs//formatjs_cli:toolchain_type"],
+    doc = "Exposes the FormatJS CLI selected by the toolchain as an executable target",
+)

--- a/tests/cli/BUILD.bazel
+++ b/tests/cli/BUILD.bazel
@@ -1,0 +1,6 @@
+load(":cli_test.bzl", "formatjs_cli_executable_test")
+
+formatjs_cli_executable_test(
+    name = "cli_executable_test",
+    cli = "//cli",
+)

--- a/tests/cli/cli_test.bzl
+++ b/tests/cli/cli_test.bzl
@@ -1,0 +1,31 @@
+"""Tests for the public FormatJS CLI executable target."""
+
+def _formatjs_cli_executable_test_impl(ctx):
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        content = """#!/usr/bin/env bash
+set -euo pipefail
+
+"${TEST_SRCDIR}/formatjs_cli" --version
+""",
+        is_executable = True,
+    )
+
+    return [DefaultInfo(
+        executable = ctx.outputs.executable,
+        runfiles = ctx.runfiles(root_symlinks = {
+            "formatjs_cli": ctx.executable.cli,
+        }),
+    )]
+
+formatjs_cli_executable_test = rule(
+    implementation = _formatjs_cli_executable_test_impl,
+    attrs = {
+        "cli": attr.label(
+            executable = True,
+            cfg = "exec",
+            mandatory = True,
+        ),
+    },
+    test = True,
+)


### PR DESCRIPTION
## Summary

- expose `@rules_formatjs//cli` as a toolchain-backed executable
- preserve native `.exe` outputs on Windows and smoke-test every supported platform
- document direct `bazel run` and executable-attribute usage

## Why

The public `:cli` alias resolved to a file target without executable `DefaultInfo`, so `bazel run` and `executable = True` attributes failed. Consumers should not need their own Starlark adapter.

## Validation

- `bazel run @rules_formatjs//cli -- --version`
- same command from `examples/simple`
- `bazel test //...`
- Buildifier and oxfmt checks
