### PR TITLE
docs: document release workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Repository guidance
+
+## Releases
+
+Follow [docs/releasing.md](docs/releasing.md).
+
+- Use `.github/workflows/tag.yaml` as the normal release entrypoint. Dispatch it
+  on `main` without inputs; it chooses the version from Conventional Commits.
+- Before dispatching, confirm `main` CI and Verify Hooks are green, no tag or
+  release run is active, the latest tag/release is known, and
+  `BCR_PUBLISH_TOKEN` is a Classic PAT with `repo` and `workflow` scopes that
+  can push to `formatjs/bazel-central-registry` and open the upstream PR.
+- Do not invent a version or push a tag for a normal patch or minor release.
+- Use `release.yaml` only to recover an existing tag that was not released. Use
+  `publish.yaml` only to retry BCR publication for an existing release.
+- A major version requires explicit confirmation. The tag workflow may create
+  the tag, but intentionally skips the release and BCR jobs for a major bump.
+- Monitor the workflow through the GitHub release and BCR handoff. Tag creation
+  alone is not completion.
+- If the BCR push rejects the token, rotate the secret and retry `publish.yaml`
+  with the existing tag. Do not rerun the tag or release jobs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,23 +44,17 @@ This means that any usage of `@rules_formatjs` on your system will point to this
 
 ## Releasing
 
-Releases are automated on a cron trigger.
-The new version is determined automatically from the commit history, assuming the commit messages follow conventions, using
-https://github.com/marketplace/actions/conventional-commits-versioner-action.
-If you do nothing, eventually the newest commits will be released automatically as a patch or minor release.
-This automation is defined in .github/workflows/tag.yaml.
+The release workflow chooses the next version from Conventional Commits, creates
+the tag and GitHub release, and opens the Bazel Central Registry PR. It also
+runs on a schedule.
 
-Rather than wait for the cron event, you can trigger manually. Navigate to
-https://github.com/formatjs/rules_formatjs/actions/workflows/tag.yaml
-and press the "Run workflow" button.
+To start a normal release without waiting for the schedule, dispatch the
+no-input tag workflow on `main`:
 
-If you need control over the next release version, for example when making a release candidate for a new major,
-then: tag the repo and push the tag, for example
-
-```sh
-% git fetch
-% git tag v1.0.0-rc0 origin/main
-% git push origin v1.0.0-rc0
+```shell
+gh workflow run tag.yaml --repo formatjs/rules_formatjs --ref main
 ```
 
-Then watch the automation run on GitHub actions which creates the release.
+Do not push a tag manually for a normal patch or minor release. See
+[docs/releasing.md](docs/releasing.md) for preflight checks, monitoring, major
+releases, and recovery.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,115 @@
+# Releasing
+
+The normal release flow starts from `main` and chooses the next version from
+Conventional Commits.
+
+```mermaid
+flowchart LR
+  tag["Tag a Release"] --> version["Create the next semver tag"]
+  version --> release["Test, build, attest, and create the GitHub release"]
+  release --> bcr["Open the Bazel Central Registry PR"]
+```
+
+## Normal release
+
+Before starting, confirm that CI and Verify Hooks are green on `main`, no tag or
+release workflow is already running, and the latest release is the one you
+expect. `BCR_PUBLISH_TOKEN` must belong to an account that can push to
+`formatjs/bazel-central-registry`. It must be a Classic PAT with `repo` and
+`workflow` scopes; fine-grained PATs cannot open the pull request against the
+public upstream registry.
+
+```sh
+gh run list \
+  --repo formatjs/rules_formatjs \
+  --workflow ci.yaml \
+  --branch main \
+  --limit 1
+
+gh run list \
+  --repo formatjs/rules_formatjs \
+  --workflow verify-hooks.yml \
+  --branch main \
+  --limit 1
+
+gh run list --repo formatjs/rules_formatjs --workflow tag.yaml --limit 5
+gh release list --repo formatjs/rules_formatjs --limit 5
+```
+
+Dispatch the tag workflow. It has no inputs.
+
+```sh
+gh workflow run tag.yaml --repo formatjs/rules_formatjs --ref main
+```
+
+The workflow uses `smlx/ccv` to inspect commits since the latest release. A
+`fix` normally produces a patch, a `feat` produces a minor, and a breaking
+change produces a major. Other commit types might not create a release.
+
+Manual dispatch bypasses the two-week guard used by the scheduled run. Do not
+push a tag or choose a version manually for a normal patch or minor release.
+
+Find and watch the dispatched run:
+
+```sh
+gh run list \
+  --repo formatjs/rules_formatjs \
+  --workflow tag.yaml \
+  --event workflow_dispatch \
+  --limit 1
+
+gh run watch RUN_ID --repo formatjs/rules_formatjs --exit-status
+```
+
+Completion means all of the following are true:
+
+- the new tag points at the intended `main` commit;
+- the GitHub release exists with the source and docs archives;
+- release attestations were created;
+- the publish job opened or updated the BCR PR.
+
+```sh
+gh release view TAG --repo formatjs/rules_formatjs
+```
+
+## Major releases
+
+The tag workflow intentionally skips the release and BCR jobs when it computes
+a major version. It may still create the tag. Confirm the version and tag before
+continuing, then release that existing tag explicitly:
+
+```sh
+gh workflow run release.yaml \
+  --repo formatjs/rules_formatjs \
+  --ref main \
+  -f tag_name=TAG
+```
+
+## Recovery
+
+Use the narrower workflows only when resuming an existing release:
+
+- If the tag exists but the GitHub release does not, dispatch `release.yaml`
+  with that tag.
+- If the GitHub release exists but BCR publication failed, dispatch
+  `publish.yaml` with that tag.
+- If the BCR push reports `Invalid username or token`, rotate
+  `BCR_PUBLISH_TOKEN` with a valid Classic PAT that has `repo` and `workflow`
+  scopes, then retry `publish.yaml`. Do not rerun the tag or release workflow.
+
+Set or rotate the repository secret interactively so the token is not written
+to shell history:
+
+```sh
+gh secret set BCR_PUBLISH_TOKEN --repo formatjs/rules_formatjs
+```
+
+```sh
+gh workflow run publish.yaml \
+  --repo formatjs/rules_formatjs \
+  --ref main \
+  -f tag_name=TAG
+```
+
+Do not use either recovery workflow to invent a new version. Do not set the
+version in `MODULE.bazel`; the BCR publisher patches it in the registry PR.


### PR DESCRIPTION
## Summary

- add repository guidance for normal releases and recovery
- replace manual tag instructions with the canonical workflow dispatch
- document versioning, completion checks, major releases, and BCR retries

## Why

The v0.8.0 run confirmed the tag, build, attestation, and GitHub release path.
It also exposed an invalid `BCR_PUBLISH_TOKEN` at the fork-push boundary, so
the docs now make that prerequisite and the publish-only retry path explicit.

## Validation

- `oxfmt --check AGENTS.md CONTRIBUTING.md docs/releasing.md`
- `git diff --check`
- exercised the normal workflow through the v0.8.0 GitHub release
