### PR TITLE
fix: open BCR pull requests for review

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,6 +24,7 @@ jobs:
     uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.2
     with:
       tag_name: ${{ inputs.tag_name }}
+      draft: false
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
       registry_fork: formatjs/bazel-central-registry
     permissions:


### PR DESCRIPTION
## What

Pass `draft: false` to the reusable BCR publish workflow so generated registry PRs open ready for review.

## Why

`publish-to-bcr@v1.4.2` defaults `draft` to `true`. The v0.9.0 release inherited that default and created bazelbuild/bazel-central-registry#9716 as a draft.

The BCR publisher uses the `formatjsproject` bot account, so there is no need for the human-author draft/auto-approval workaround described by the upstream workflow.

## Validation

- parsed `.github/workflows/publish.yaml` with Ruby YAML
- `git diff --check`
- confirmed the v0.9.0 publish log passed `DRAFT: true` before this override
