### PR TITLE
feat: support Rust extraction sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bazel rules for [FormatJS](https://formatjs.io/) - Internationalize your web app
 
 ## Features
 
-- Extract messages from source files (TypeScript, JavaScript, JSX, TSX)
+- Extract messages from source files (TypeScript, JavaScript, JSX, TSX, Rust)
 - Compile messages for optimized runtime performance
 - Verify translations for completeness
 - Aggregate messages across multiple modules

--- a/formatjs/extract.bzl
+++ b/formatjs/extract.bzl
@@ -1,7 +1,7 @@
 """Rules for extracting internationalized messages from source files.
 
 This module provides the `formatjs_extract` rule for extracting messages from
-TypeScript, JavaScript, JSX, and TSX files using the FormatJS CLI. The extracted
+TypeScript, JavaScript, JSX, TSX, and Rust files using the FormatJS CLI. The extracted
 messages are output in JSON format with automatic key sorting.
 
 The FormatJS CLI supports various message formats including:
@@ -112,7 +112,7 @@ formatjs_extract = rule(
     implementation = _formatjs_extract_impl,
     doc = """Extract internationalized messages from source files using FormatJS CLI.
 
-    This rule extracts i18n messages from TypeScript, JavaScript, JSX, and TSX files
+    This rule extracts i18n messages from TypeScript, JavaScript, JSX, TSX, and Rust files
     using the native FormatJS CLI toolchain. The extracted messages are output as a
     JSON file with alphabetically sorted keys for deterministic builds.
 
@@ -182,10 +182,11 @@ formatjs_extract = rule(
     """,
     attrs = {
         "srcs": attr.label_list(
-            allow_files = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"],
+            allow_files = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".rs"],
             doc = """Source files to extract messages from.
 
-            Supports TypeScript (.ts, .tsx), JavaScript (.js, .jsx), and ES modules (.mjs, .cjs).
+            Supports TypeScript (.ts, .tsx), JavaScript (.js, .jsx), ES modules (.mjs, .cjs),
+            and Rust (.rs).
             Use glob patterns to extract from multiple files:
             ```starlark
             srcs = glob(["src/**/*.{ts,tsx}"])

--- a/tests/arguments/BUILD.bazel
+++ b/tests/arguments/BUILD.bazel
@@ -54,8 +54,14 @@ formatjs_extract(
     id_interpolation_pattern = "[sha512:contenthash:base64:6]",
 )
 
+# Test extraction from Rust message descriptors
+formatjs_extract(
+    name = "messages_rust",
+    srcs = ["test.rs"],
+)
+
 # Note: Testing with invalid file extensions is not possible because Bazel's
-# allow_files restriction on srcs prevents non-JS/TS files at analysis time.
+# allow_files restriction on srcs prevents unsupported files at analysis time.
 # This is actually good - it provides early validation before the CLI runs.
 
 # Test compilation with ast parameter
@@ -93,6 +99,7 @@ write_source_files(
         "fixtures/messages_default.json": ":messages_default",
         "fixtures/messages_merge.json": ":messages_merge",
         "fixtures/messages_crowdin.json": ":messages_crowdin",
+        "fixtures/messages_rust.json": ":messages_rust",
         "fixtures/compiled_ast.json": ":compiled_ast",
         "fixtures/compiled_multiple.json": ":compiled_multiple",
     },
@@ -106,6 +113,7 @@ write_source_files(
         "fixtures/messages_default.json": ":messages_default",
         "fixtures/messages_merge.json": ":messages_merge",
         "fixtures/messages_crowdin.json": ":messages_crowdin",
+        "fixtures/messages_rust.json": ":messages_rust",
         "fixtures/compiled_ast.json": ":compiled_ast",
         "fixtures/compiled_multiple.json": ":compiled_multiple",
     },

--- a/tests/arguments/fixtures/messages_rust.json
+++ b/tests/arguments/fixtures/messages_rust.json
@@ -1,0 +1,6 @@
+{
+  "rust.greeting": {
+    "defaultMessage": "Hello from Rust!",
+    "description": "Greeting from Rust"
+  }
+}

--- a/tests/arguments/test.rs
+++ b/tests/arguments/test.rs
@@ -1,0 +1,5 @@
+const GREETING: formatjs_intl::MessageDescriptor = formatjs_intl::message_descriptor!(
+    id: "rust.greeting",
+    default_message: "Hello from Rust!",
+    description: "Greeting from Rust"
+);


### PR DESCRIPTION
## Summary

- allow `.rs` inputs in `formatjs_extract`
- document Rust source support
- cover `message_descriptor!` extraction with a fixture

## Testing

- `bazel test //tests/arguments:test_fixtures_5_test --test_output=errors`
- `bazel test //...`
